### PR TITLE
1.0.1

### DIFF
--- a/ResourcepackGuide/PackSetup.md
+++ b/ResourcepackGuide/PackSetup.md
@@ -33,7 +33,6 @@ The files in the `luminance/` folder look like this:
   "post_effect": "<namespace:id>",
   "enabled": true,
   "disable_game_rendertype": <...>,
-  
   "registries": [ ... ],
   "custom": {
     "souper_secret_settings": {
@@ -44,15 +43,15 @@ The files in the `luminance/` folder look like this:
 ```
 
 `"post_effect"` is what file in the `post_effect/` folder the shader is using, for instance `"minecraft:sobel"` would point to `minecraft/post_effect/sobel.json`.
-- the name of the file itself can be called anything, but it should usually be named the id for consistency (so in this case `sobel`)
-- the value in the `"post_effect"` field is what the shader will be referred to with
+- the name of the file itself can be anything (the value in `"post_effect"` is what the shader will be referred to as by luminance)
+- but it should usually be named the id for consistency (so in this case `sobel`)
+- if the field is missing, the filename and namespace of the file is used (so `assets/*minecraft*/luminance/*sobel*.json` will have a default `"post_effect"` of `minecaft:sobel`)
 
-`"enabled"` is whether the shader is enabled, see [below](#changing-shaders) for details
+`"enabled"` is whether the shader is enabled, see [below](#changing-shaders) for details, by default it is `true`
 
 `"disable_game_rendertype"` is whether the shader should be allowed to be rendered after ui (false), or if it can only be rendered before (true). This is done when the shader uses depth (since depth doesnt work properly after ui), or when the shader disruptive enough to make ui unreadable.
 - soup does not adhere to this, instead having a button that toggles rendering between game and world
-
-## Optional fields
+- by default this is `false`
 
 `"registries"` is what lists of shaders the shader will show up in
 - `"luminance:main"`: default value if the field is missing, this is where soup and perspective look to get the list of shaders that can be used

--- a/ResourcepackGuide/PackSetup.md
+++ b/ResourcepackGuide/PackSetup.md
@@ -32,7 +32,7 @@ The files in the `luminance/` folder look like this:
 {
   "post_effect": "<namespace:id>",
   "enabled": true,
-  "disable_game_rendertype": <...>,
+  "disable_ui_rendertype": <...>,
   "registries": [ ... ],
   "custom": {
     "souper_secret_settings": {
@@ -49,7 +49,7 @@ The files in the `luminance/` folder look like this:
 
 `"enabled"` is whether the shader is enabled, see [below](#changing-shaders) for details, by default it is `true`
 
-`"disable_game_rendertype"` is whether the shader should be allowed to be rendered after ui (false), or if it can only be rendered before (true). This is done when the shader uses depth (since depth doesnt work properly after ui), or when the shader disruptive enough to make ui unreadable.
+`"disable_ui_rendertype"` is whether the shader should be allowed to be rendered after ui (false), or if it can only be rendered before (true). This is done when the shader uses depth (since depth doesnt work properly after ui), or when the shader disruptive enough to make ui unreadable.
 - soup does not adhere to this, instead having a button that toggles rendering between game and world
 - by default this is `false`
 

--- a/ResourcepackGuide/Soup.md
+++ b/ResourcepackGuide/Soup.md
@@ -103,7 +103,7 @@ assets/soup/luminance/mix.json
 {
   "post_effect": "soup:mix",
   "enabled": true,
-  "disable_game_rendertype": true,
+  "disable_ui_rendertype": true,
   "registries": [
     "souper_secret_settings:modifiers" <- this is important!
   ],

--- a/common/src/main/java/com/mclegoman/luminance/client/events/Execute.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/events/Execute.java
@@ -52,7 +52,7 @@ public class Execute {
 		SpectatorHandler.clearActive();
 	}
 	public static void beforeInGameHudRender(DrawContext context, RenderTickCounter renderTickCounter) {
-		ShaderTime.currentRendertype = Shader.RenderType.UI;
+		ShaderTime.currentRenderType = Shader.RenderType.UI;
 		Events.BeforeInGameHudRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(context, renderTickCounter);
@@ -71,7 +71,7 @@ public class Execute {
 		}));
 	}
 	public static void beforeGameRender() {
-		ShaderTime.currentRendertype = Shader.RenderType.WORLD;
+		ShaderTime.currentRenderType = Shader.RenderType.WORLD;
 		Events.BeforeGameRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run();
@@ -103,8 +103,8 @@ public class Execute {
 		}));
 	}
 	public static void afterUiBackgroundRender(ObjectAllocator allocator) {
-		Shader.RenderType previous = ShaderTime.currentRendertype;
-		ShaderTime.currentRendertype = Shader.RenderType.UI_BACKGROUND;
+		Shader.RenderType previous = ShaderTime.currentRenderType;
+		ShaderTime.currentRenderType = Shader.RenderType.UI_BACKGROUND;
 		Events.AfterUiBackgroundRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(ClientData.minecraft.getFramebuffer(), allocator);
@@ -113,11 +113,11 @@ public class Execute {
 			}
 		}));
 		// this and afterPanoramaRender are a special case, so resetting the RenderType it makes sense
-		ShaderTime.currentRendertype = previous;
+		ShaderTime.currentRenderType = previous;
 	}
 	public static void afterPanoramaRender(ObjectAllocator allocator) {
-		Shader.RenderType previous = ShaderTime.currentRendertype;
-		ShaderTime.currentRendertype = Shader.RenderType.PANORAMA;
+		Shader.RenderType previous = ShaderTime.currentRenderType;
+		ShaderTime.currentRenderType = Shader.RenderType.PANORAMA;
 		Events.AfterPanoramaRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(ClientData.minecraft.getFramebuffer(), allocator);
@@ -125,13 +125,13 @@ public class Execute {
 				Data.getVersion().sendToLog(LogType.ERROR, Translation.getString("Failed to execute AfterPanoramaRender event with id: {}: {}", id, error));
 			}
 		}));
-		ShaderTime.currentRendertype = previous;
+		ShaderTime.currentRenderType = previous;
 	}
 	public static void resize(int width, int height) {
 		Events.OnResized.registry.forEach((id, runnable) -> runnable.run(width, height));
 	}
 	public static void beforeWorldRender() {
-		ShaderTime.currentRendertype = Shader.RenderType.WORLD;
+		ShaderTime.currentRenderType = Shader.RenderType.WORLD;
 		Events.BeforeWorldRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run();

--- a/common/src/main/java/com/mclegoman/luminance/client/events/Execute.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/events/Execute.java
@@ -9,6 +9,8 @@ package com.mclegoman.luminance.client.events;
 
 import com.mclegoman.luminance.client.config.LuminanceConfig;
 import com.mclegoman.luminance.client.data.ClientData;
+import com.mclegoman.luminance.client.shaders.Shader;
+import com.mclegoman.luminance.client.shaders.ShaderTime;
 import com.mclegoman.luminance.client.shaders.SpectatorHandler;
 import com.mclegoman.luminance.client.shaders.interfaces.FramePassInterface;
 import com.mclegoman.luminance.client.translation.Translation;
@@ -50,6 +52,7 @@ public class Execute {
 		SpectatorHandler.clearActive();
 	}
 	public static void beforeInGameHudRender(DrawContext context, RenderTickCounter renderTickCounter) {
+		ShaderTime.currentRendertype = Shader.RenderType.UI;
 		Events.BeforeInGameHudRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(context, renderTickCounter);
@@ -68,6 +71,7 @@ public class Execute {
 		}));
 	}
 	public static void beforeGameRender() {
+		ShaderTime.currentRendertype = Shader.RenderType.WORLD;
 		Events.BeforeGameRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run();
@@ -98,7 +102,9 @@ public class Execute {
 			}
 		}));
 	}
-	public static void afterScreenBackgroundRender(ObjectAllocator allocator) {
+	public static void afterUiBackgroundRender(ObjectAllocator allocator) {
+		Shader.RenderType previous = ShaderTime.currentRendertype;
+		ShaderTime.currentRendertype = Shader.RenderType.UI_BACKGROUND;
 		Events.AfterUiBackgroundRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(ClientData.minecraft.getFramebuffer(), allocator);
@@ -106,8 +112,12 @@ public class Execute {
 				Data.getVersion().sendToLog(LogType.ERROR, Translation.getString("Failed to execute AfterScreenBackgroundRender event with id: {}: {}", id, error));
 			}
 		}));
+		// this and afterPanoramaRender are a special case, so resetting the RenderType it makes sense
+		ShaderTime.currentRendertype = previous;
 	}
 	public static void afterPanoramaRender(ObjectAllocator allocator) {
+		Shader.RenderType previous = ShaderTime.currentRendertype;
+		ShaderTime.currentRendertype = Shader.RenderType.PANORAMA;
 		Events.AfterPanoramaRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run(ClientData.minecraft.getFramebuffer(), allocator);
@@ -115,11 +125,13 @@ public class Execute {
 				Data.getVersion().sendToLog(LogType.ERROR, Translation.getString("Failed to execute AfterPanoramaRender event with id: {}: {}", id, error));
 			}
 		}));
+		ShaderTime.currentRendertype = previous;
 	}
 	public static void resize(int width, int height) {
 		Events.OnResized.registry.forEach((id, runnable) -> runnable.run(width, height));
 	}
 	public static void beforeWorldRender() {
+		ShaderTime.currentRendertype = Shader.RenderType.WORLD;
 		Events.BeforeWorldRender.registry.forEach(((id, runnable) -> {
 			try {
 				runnable.run();

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/ShaderTime.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/ShaderTime.java
@@ -21,7 +21,7 @@ public class ShaderTime {
     private float expDelta;
 
     // current position in the rendering pipeline
-    public static Shader.RenderType currentRendertype;
+    public static Shader.RenderType currentRenderType;
 
     public void update(float tickDelta) {
         this.tickDelta = tickDelta;

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/ShaderTime.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/ShaderTime.java
@@ -20,6 +20,9 @@ public class ShaderTime {
     public static final float defaultSpeed = 1f;
     private float expDelta;
 
+    // current position in the rendering pipeline
+    public static Shader.RenderType currentRendertype;
+
     public void update(float tickDelta) {
         this.tickDelta = tickDelta;
         deltaTime = ((tickDelta < prevTickDelta ? 1 : 0) + tickDelta-prevTickDelta);

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
@@ -112,6 +112,7 @@ public class Uniforms {
 			registerSingleTree(path, "starBrightness", Uniforms::getStarBrightness, 0f, 1f);
 			registerStandardTree(path, "time", Uniforms::getGameTime, 0f, 1f, 1, new MapConfig(List.of(new ConfigData("period", List.of(1.0f)))), false);
 			registerStandardTree(path, "random", Uniforms::getRandom, 0f, 1f, 1, EmptyConfig.INSTANCE, false);
+			registerStandardTree(path, "renderType", Uniforms::getRenderType, 0f, (float)Shader.RenderType.values().length-1, 1, EmptyConfig.INSTANCE, false);
 		} catch (Exception error) {
 			Data.getVersion().sendToLog(LogType.ERROR, Translation.getString("Failed to initialize uniforms: {}", error));
 		}
@@ -395,6 +396,9 @@ public class Uniforms {
 	}
 	public static void getRandom(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
 		uniformValue.set(0, Accessors.getGameRenderer().getRandom().nextFloat());
+	}
+	public static void getRenderType(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
+		uniformValue.set(0, ShaderTime.currentRendertype.getId());
 	}
 	public static void getZero(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
 		uniformValue.set(0, 0F);

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
@@ -398,7 +398,7 @@ public class Uniforms {
 		uniformValue.set(0, Accessors.getGameRenderer().getRandom().nextFloat());
 	}
 	public static void getRenderType(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
-		uniformValue.set(0, ShaderTime.currentRendertype.getId());
+		uniformValue.set(0, ShaderTime.currentRenderType.getId());
 	}
 	public static void getZero(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
 		uniformValue.set(0, 0F);

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
@@ -34,14 +34,18 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.option.Perspective;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 public class Uniforms {
 	public static ShaderTime shaderTime = new ShaderTime();
@@ -96,6 +100,8 @@ public class Uniforms {
 			registerSingleTree(path, "isInvisible", Uniforms::getIsInvisible, 0f, 1f);
 			registerSingleTree(path, "isWithered", (shaderTime) -> Uniforms.getHasEffect(StatusEffects.WITHER), 0f, 1f);
 			registerSingleTree(path, "isPoisoned", (shaderTime) -> Uniforms.getHasEffect(StatusEffects.POISON), 0f, 1f);
+			registerStandardTree(path, "effectDuration", Uniforms::getEffectDuration, null, null, 1, new MapConfig(List.of(new ConfigData("effect", List.of("minecraft:speed")))), false);
+			registerStandardTree(path, "effectAmplifier", Uniforms::getEffectAmplifier, 0f, 255f, 1, new MapConfig(List.of(new ConfigData("effect", List.of("minecraft:speed")))), false);
 			registerSingleTree(path, "isBurning", Uniforms::getIsBurning, 0f, 1f);
 			registerSingleTree(path, "isOnGround", Uniforms::getIsOnGround, 0f, 1f);
 			registerSingleTree(path, "isOnLadder", Uniforms::getIsOnLadder, 0f, 1f);
@@ -308,6 +314,25 @@ public class Uniforms {
 	public static float getHasEffect(RegistryEntry<StatusEffect> statusEffect) {
 		return ClientData.minecraft.player != null ? (ClientData.minecraft.player.hasStatusEffect(statusEffect) ? 1.0F : 0.0F) : 0.0F;
 	}
+	public static void getEffectDuration(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
+		StatusEffectInstance instance = getEffect(config);
+		uniformValue.set(0, instance == null ? 0 : instance.getDuration());
+	}
+	public static void getEffectAmplifier(UniformConfig config, ShaderTime shaderTime, UniformValue uniformValue) {
+		StatusEffectInstance instance = getEffect(config);
+		uniformValue.set(0, instance == null ? 0 : instance.getAmplifier());
+	}
+	private static @Nullable StatusEffectInstance getEffect(UniformConfig config) {
+		List<Object> objects = config.getObjects("effect");
+		if (ClientData.minecraft.player != null && objects != null && !objects.isEmpty() && objects.getFirst() instanceof String id) {
+			Optional<RegistryEntry.Reference<StatusEffect>> entry = Registries.STATUS_EFFECT.getEntry(Identifier.of(id));
+			if (entry.isPresent()) {
+				return ClientData.minecraft.player.getStatusEffect(entry.get());
+			}
+		}
+		return null;
+	}
+
 	public static float getIsBurning(ShaderTime shaderTime) {
 		return ClientData.minecraft.player != null ? (ClientData.minecraft.player.isOnFire() ? 1.0F : 0.0F) : 0.0F;
 	}

--- a/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
+++ b/common/src/main/java/com/mclegoman/luminance/client/shaders/Uniforms.java
@@ -363,7 +363,7 @@ public class Uniforms {
 			Perspective perspective = ClientData.minecraft.options.getPerspective();
 			return perspective.equals(Perspective.THIRD_PERSON_FRONT) ? 3.0F : (perspective.equals(Perspective.THIRD_PERSON_BACK) ? 2.0F : (perspective.equals(Perspective.FIRST_PERSON) ? 1.0F : 0.0F));
 		}
-		return 1.0F;
+		return 0.0F;
 	}
 	public static float getSelectedSlot(ShaderTime shaderTime) {
 		return ClientData.minecraft.player != null ? ClientData.minecraft.player.getInventory().selectedSlot : 0.0F;

--- a/common/src/main/java/com/mclegoman/luminance/mixin/client/shaders/ScreenMixin.java
+++ b/common/src/main/java/com/mclegoman/luminance/mixin/client/shaders/ScreenMixin.java
@@ -20,6 +20,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ScreenMixin {
 	@Inject(method = "renderBackground", at = @At("RETURN"))
 	private void luminance$afterBackgroundRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-		Execute.afterScreenBackgroundRender(((GameRendererAccessor) ClientData.minecraft.gameRenderer).getPool());
+		Execute.afterUiBackgroundRender(((GameRendererAccessor) ClientData.minecraft.gameRenderer).getPool());
 	}
 }

--- a/common/src/main/java/com/mclegoman/luminance/mixin/client/shaders/TitleScreenMixin.java
+++ b/common/src/main/java/com/mclegoman/luminance/mixin/client/shaders/TitleScreenMixin.java
@@ -20,6 +20,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class TitleScreenMixin {
 	@Inject(method = "renderBackground", at = @At("RETURN"))
 	private void luminance$afterBackgroundRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-		Execute.afterScreenBackgroundRender(((GameRendererAccessor) ClientData.minecraft.gameRenderer).getPool());
+		Execute.afterUiBackgroundRender(((GameRendererAccessor) ClientData.minecraft.gameRenderer).getPool());
 	}
 }

--- a/common/src/main/resources/assets/luminance/shaders/post/color_overlay.fsh
+++ b/common/src/main/resources/assets/luminance/shaders/post/color_overlay.fsh
@@ -1,0 +1,11 @@
+#version 150
+
+in vec2 texCoord;
+uniform sampler2D InSampler;
+uniform vec4 Color;
+out vec4 fragColor;
+
+void main() {
+    vec4 c = texture(InSampler, texCoord);
+    fragColor = vec4(mix(c.rgb, Color.rgb, Color.a), c.a);
+}

--- a/common/src/main/resources/assets/luminance/shaders/post/color_overlay.json
+++ b/common/src/main/resources/assets/luminance/shaders/post/color_overlay.json
@@ -1,0 +1,12 @@
+{
+	"vertex": "minecraft:post/sobel",
+	"fragment": "luminance:post/color_overlay",
+	"samplers": [
+		{ "name": "InSampler" }
+	],
+	"uniforms": [
+		{ "name": "ProjMat",                "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+		{ "name": "OutSize",                "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+		{ "name": "Color",        "type": "float",     "count": 4,  "values": [ 0.0, 0.0, 0.0, 1.0 ] }
+	]
+}

--- a/common/src/main/resources/assets/luminance/shaders/post/outlined.fsh
+++ b/common/src/main/resources/assets/luminance/shaders/post/outlined.fsh
@@ -25,11 +25,6 @@ uniform float OutlineColorMultiplier;
 uniform float Silhouette;
 uniform vec3 SilhouetteColor;
 uniform float Distance;
-uniform float luminance_alpha_smooth;
-
-//vec4 color_layers[6];
-//float depth_layers[6];
-//int active_layers = 0;
 
 out vec4 fragColor;
 
@@ -76,62 +71,11 @@ vec4 outline( vec4 color, sampler2D DepthSampler ) {
     float depth4;
     if (Distance < 0) depth4 = min(max(1.0 - depth, 0.0), 1.0);
     else depth4 = min(max(1.0 - (1.0 - depth) * ((Distance * 16) * 0.64), 0.0), 1.0);
-    return vec4(mix(color.rgb, mix(outputColor.rgb, color.rgb, smoothstep(0.9, 0.91, depth4)), luminance_alpha_smooth), outputColor.a);
+    return vec4(mix(outputColor.rgb, color.rgb, smoothstep(0.9, 0.91, depth4)), outputColor.a);
 }
 
-//void try_insert( vec4 color, sampler2D DepthSampler ) {
-//    if ( color.a == 0.0 ) {
-//        return;
-//    }
-//    float depth = texture( DepthSampler, texCoord ).r;
-//
-//    if (Silhouette != 0) color = vec4(mix(color.rgb, SilhouetteColor, luminance_alpha_smooth), 1.0);
-//
-//    color = outline(color, DepthSampler);
-//
-//    color_layers[active_layers] = color;
-//    depth_layers[active_layers] = depth;
-//
-//    int next_layer = active_layers++;
-//    int current_layer = next_layer - 1;
-//    while ( next_layer > 0 && depth_layers[next_layer] > depth_layers[current_layer] ) {
-//        float depthTemp = depth_layers[current_layer];
-//        depth_layers[current_layer] = depth_layers[next_layer];
-//        depth_layers[next_layer] = depthTemp;
-//
-//        vec4 colorTemp = color_layers[current_layer];
-//        color_layers[current_layer] = color_layers[next_layer];
-//        color_layers[next_layer] = colorTemp;
-//
-//        next_layer = current_layer--;
-//    }
-//}
-
-//vec3 blend( vec3 dst, vec4 src ) {
-//    return ( dst * ( 1.0 - src.a ) ) + src.rgb;
-//}
-
 void main() {
-    vec4 color;
     vec4 baseColor = texture(InSampler, texCoord);
-    color = mix(baseColor, vec4(SilhouetteColor, 1.0), Silhouette);
-
-    color = outline(color, InDepthSampler);
-
-    //color_layers[0] = vec4(mix(texture(InSampler, texCoord).rgb, outline(color, InDepthSampler).rgb, luminance_alpha_smooth), 1.0);
-    //depth_layers[0] = texture(InDepthSampler, texCoord).r;
-    //active_layers = 1;
-
-    //try_insert( texture( TranslucentSampler, texCoord ), TranslucentDepthSampler );
-    //try_insert( texture( ItemEntitySampler, texCoord ), ItemEntityDepthSampler );
-    //try_insert( texture( ParticlesSampler, texCoord ), ParticlesDepthSampler );
-    //try_insert( texture( WeatherSampler, texCoord ), WeatherDepthSampler );
-    //try_insert( texture( CloudsSampler, texCoord ), CloudsDepthSampler );
-
-    //vec3 texelAccum = color_layers[0].rgb;
-    //for ( int ii = 1; ii < active_layers; ++ii ) {
-    //    texelAccum = blend( texelAccum, color_layers[ii] );
-    //}
-
-    fragColor = vec4(mix(baseColor.rgb, color.rgb, luminance_alpha_smooth), 1.0);
+    vec4 color = outline(baseColor, InDepthSampler);
+    fragColor = vec4(color.rgb, baseColor.a);
 }

--- a/common/src/main/resources/assets/luminance/shaders/post/outlined.json
+++ b/common/src/main/resources/assets/luminance/shaders/post/outlined.json
@@ -20,13 +20,10 @@
 		{ "name": "OutSize",                "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
 		{ "name": "Transparency",           "type": "float",     "count": 1,  "values": [ 0.25 ] },
 		{ "name": "Thickness",              "type": "float",     "count": 1,  "values": [ 0.0033 ] },
-		{ "name": "Silhouette",             "type": "float",     "count": 1,  "values": [ 0.0 ] },
-		{ "name": "SilhouetteColor",        "type": "float",     "count": 3,  "values": [ 0.0, 0.0, 0.0 ] },
 		{ "name": "Outline",                "type": "float",     "count": 1,  "values": [ 0.0 ] },
 		{ "name": "OutlineColor",           "type": "float",     "count": 3,  "values": [ 1.0, 1.0, 1.0 ] },
 		{ "name": "OutlinePow",             "type": "float",     "count": 3,  "values": [ 0.5, 0.5, 0.5 ] },
 		{ "name": "OutlineColorMultiplier", "type": "float",     "count": 1,  "values": [ 1.0 ] },
-		{ "name": "Distance", "type": "float",     "count": 1,  "values": [ -1.0 ] },
-		{ "name": "luminance_alpha_smooth", "type": "float",     "count": 1,  "values": [ 1.0 ] }
+		{ "name": "Distance", "type": "float",     "count": 1,  "values": [ -1.0 ] }
 	]
 }

--- a/common/src/main/resources/assets/minecraft/luminance/box_blur.json
+++ b/common/src/main/resources/assets/minecraft/luminance/box_blur.json
@@ -1,7 +1,7 @@
 {
   "post_effect": "minecraft:box_blur",
   "enabled": true,
-  "disable_game_rendertype": true,
+  "disable_ui_rendertype": true,
   "custom": {
     "souper_secret_settings": {
       "groups": [ "edible", "blur" ]

--- a/common/src/main/resources/assets/minecraft/luminance/creeper.json
+++ b/common/src/main/resources/assets/minecraft/luminance/creeper.json
@@ -1,7 +1,7 @@
 {
   "post_effect": "minecraft:creeper",
   "enabled": true,
-  "disable_game_rendertype": true,
+  "disable_ui_rendertype": true,
   "custom": {
     "souper_secret_settings": {
       "groups": [ "edible", "retro" ]

--- a/common/src/main/resources/assets/minecraft/luminance/invert.json
+++ b/common/src/main/resources/assets/minecraft/luminance/invert.json
@@ -1,7 +1,7 @@
 {
   "post_effect": "minecraft:invert",
   "enabled": true,
-  "disable_game_rendertype": false,
+  "disable_ui_rendertype": false,
   "custom": {
     "souper_secret_settings": {
       "groups": [ "edible", "filter" ]

--- a/common/src/main/resources/assets/minecraft/luminance/spider.json
+++ b/common/src/main/resources/assets/minecraft/luminance/spider.json
@@ -1,7 +1,7 @@
 {
   "post_effect": "minecraft:spider",
   "enabled": true,
-  "disable_game_rendertype": true,
+  "disable_ui_rendertype": true,
   "custom": {
     "souper_secret_settings": {
       "groups": [ "edible" ]

--- a/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/outlined.json
+++ b/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/outlined.json
@@ -1,6 +1,7 @@
 {
     "targets": {
-        "0": {}
+        "0": {},
+        "1": {}
     },
     "passes": [
         {
@@ -64,11 +65,25 @@
             "output": "0"
         },
         {
-            "program": "minecraft:post/blit",
+            "program": "luminance:post/merge",
             "inputs": [
                 {
                     "sampler_name": "In",
                     "target": "0"
+                },
+                {
+                    "sampler_name": "Merge",
+                    "target": "minecraft:main"
+                }
+            ],
+            "output": "1"
+        },
+        {
+            "program": "minecraft:post/blit",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "1"
                 }
             ],
             "output": "minecraft:main"

--- a/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/outlined2.json
+++ b/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/outlined2.json
@@ -1,6 +1,7 @@
 {
     "targets": {
-        "0": {}
+        "0": {},
+        "1": {}
     },
     "passes": [
         {
@@ -86,11 +87,25 @@
             ]
         },
         {
-            "program": "minecraft:post/blit",
+            "program": "luminance:post/merge",
             "inputs": [
                 {
                     "sampler_name": "In",
                     "target": "0"
+                },
+                {
+                    "sampler_name": "Merge",
+                    "target": "minecraft:main"
+                }
+            ],
+            "output": "1"
+        },
+        {
+            "program": "minecraft:post/blit",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "1"
                 }
             ],
             "output": "minecraft:main"

--- a/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/silhouette.json
+++ b/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/silhouette.json
@@ -1,14 +1,32 @@
 {
     "targets": {
-        "0": {}
+        "0": {},
+        "1": {},
+        "2": {}
     },
     "passes": [
+        {
+            "program": "luminance:post/color_overlay",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "minecraft:main"
+                }
+            ],
+            "uniforms": [
+                {
+                    "name": "Color",
+                    "values": [ 0.0, 0.0, 0.0, 1.0 ]
+                }
+            ],
+            "output": "0"
+        },
         {
             "program": "luminance:post/outlined",
             "inputs": [
                 {
                     "sampler_name": "In",
-                    "target": "minecraft:main"
+                    "target": "0"
                 },
                 {
                     "sampler_name": "InDepth",
@@ -61,28 +79,34 @@
                     "use_depth_buffer": true
                 }
             ],
-            "output": "0",
+            "output": "1",
             "uniforms": [
                 {
                     "name": "Transparency",
                     "values": [ 0.5 ]
-                },
-                {
-                    "name": "Silhouette",
-                    "values": [ 1.0 ]
-                },
-                {
-                    "name": "SilhouetteColor",
-                    "values": [ 0.0, 0.0, 0.0 ]
                 }
             ]
+        },
+        {
+            "program": "luminance:post/merge",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "1"
+                },
+                {
+                    "sampler_name": "Merge",
+                    "target": "minecraft:main"
+                }
+            ],
+            "output": "2"
         },
         {
             "program": "minecraft:post/blit",
             "inputs": [
                 {
                     "sampler_name": "In",
-                    "target": "0"
+                    "target": "2"
                 }
             ],
             "output": "minecraft:main"

--- a/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/silhouette2.json
+++ b/common/src/main/resources/resourcepacks/luminance_default/assets/luminance/post_effect/silhouette2.json
@@ -1,14 +1,32 @@
 {
     "targets": {
-        "0": {}
+        "0": {},
+        "1": {},
+        "2": {}
     },
     "passes": [
+        {
+            "program": "luminance:post/color_overlay",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "minecraft:main"
+                }
+            ],
+            "uniforms": [
+                {
+                    "name": "Color",
+                    "values": [ 1.0, 1.0, 1.0, 1.0 ]
+                }
+            ],
+            "output": "0"
+        },
         {
             "program": "luminance:post/outlined",
             "inputs": [
                 {
                     "sampler_name": "In",
-                    "target": "minecraft:main"
+                    "target": "0"
                 },
                 {
                     "sampler_name": "InDepth",
@@ -61,19 +79,11 @@
                     "use_depth_buffer": true
                 }
             ],
-            "output": "0",
+            "output": "1",
             "uniforms": [
                 {
                     "name": "Transparency",
                     "values": [ 0.5 ]
-                },
-                {
-                    "name": "Silhouette",
-                    "values": [ 1.0 ]
-                },
-                {
-                    "name": "SilhouetteColor",
-                    "values": [ 1.0, 1.0, 1.0 ]
                 },
                 {
                     "name": "OutlineColorMultiplier",
@@ -82,11 +92,25 @@
             ]
         },
         {
+            "program": "luminance:post/merge",
+            "inputs": [
+                {
+                    "sampler_name": "In",
+                    "target": "1"
+                },
+                {
+                    "sampler_name": "Merge",
+                    "target": "minecraft:main"
+                }
+            ],
+            "output": "2"
+        },
+        {
             "program": "minecraft:post/blit",
             "inputs": [
                 {
                     "sampler_name": "In",
-                    "target": "0"
+                    "target": "2"
                 }
             ],
             "output": "minecraft:main"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx4G
 org.gradle.parallel = true
 
 # MOD VERSIONING
-mod_version = 1.0.0-release.1
+mod_version = 1.1.0-alpha.1
 mc_version = 1.21.4
 maven_group = com.mclegoman
 archive_name = luminance


### PR DESCRIPTION
- getPerspective should default to 0.0F. (legotaylor)
- added luminance:post/color_overlay shader, (legotaylor)
- updated silhouette shaders to use color_overlay shader. (legotaylor)
- added new uniform luminance_renderType, that returns the most appropriate rendertype for where the game currently is in its render loop (nettakrim)
- added uniforms for arbitrary effect duration and amplitude (presence can be checked by seeing if duration is anything other than 0 [-1 is infinite]), defaults to speed (nettakrim)
